### PR TITLE
Add addon-checker and automatic submissions on tagging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitignore export-ignore
+.gitattributes export-ignore
+.github export-ignore

--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -1,0 +1,16 @@
+name: Kodi Addon-Check
+
+on: [push]
+
+jobs:
+  kodi-addon-checker:
+    runs-on: ubuntu-latest
+    name: Kodi addon checker
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Kodi addon checker validation
+      id: kodi-addon-checker
+      uses: enen92/action-kodi-addon-checker@v1.0
+      with:
+        kodi-version: 'gotham'

--- a/.github/workflows/addon-submitter.yml
+++ b/.github/workflows/addon-submitter.yml
@@ -1,0 +1,45 @@
+name: Kodi Addon-Submitter
+
+on:
+  create:
+    tags:
+      - v*
+
+jobs:
+  kodi-addon-submitter:
+    runs-on: ubuntu-latest
+    name: Kodi addon submitter
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Generate distribution zip and submit to official kodi repository
+      id: kodi-addon-submitter
+      uses: enen92/action-kodi-addon-submitter@v1.0
+      with: # Replace all the below values
+        kodi-repository: 'repo-scripts'
+        kodi-version: 'gotham'
+        addon-id: 'script.logviewer'
+      env: # Make sure you create the below secrets (GH_TOKEN and EMAIL)
+        GH_USERNAME: ${{ github.actor }}
+        GH_TOKEN: ${{secrets.GH_TOKEN}}
+        EMAIL: ${{secrets.EMAIL}}
+    - name: Create Github Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    - name: Upload Addon zip to github release
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.kodi-addon-submitter.outputs.addon-zip }}
+        asset_name: ${{ steps.kodi-addon-submitter.outputs.addon-zip }}
+        asset_content_type: application/zip


### PR DESCRIPTION
1) Make sure you have the `GH_TOKEN` secret defined to a personal access token with the `repo` permisson (and an `EMAIL` secret).
2) Make sure you have a fork of https://github.com/xbmc/repo-scripts under your account
3) Merge the PR
4) `git tag 2.1.0 && git push --tags`