### PR TITLE
Actions are now stored under the xbmc repo

### DIFF
--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -11,6 +11,6 @@ jobs:
       uses: actions/checkout@v1
     - name: Kodi addon checker validation
       id: kodi-addon-checker
-      uses: enen92/action-kodi-addon-checker@v1.0
+      uses: xbmc/action-kodi-addon-checker@v1.0
       with:
-        kodi-version: 'gotham'
+        kodi-version: gotham

--- a/.github/workflows/addon-submitter.yml
+++ b/.github/workflows/addon-submitter.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/checkout@v1
     - name: Generate distribution zip and submit to official kodi repository
       id: kodi-addon-submitter
-      uses: enen92/action-kodi-addon-submitter@v1.0
+      uses: xbmc/action-kodi-addon-submitter@v1.0
       with: # Replace all the below values
-        kodi-repository: 'repo-scripts'
-        kodi-version: 'gotham'
-        addon-id: 'script.logviewer'
+        kodi-repository: repo-scripts
+        kodi-version: gotham
+        addon-id: script.logviewer
       env: # Make sure you create the below secrets (GH_TOKEN and EMAIL)
         GH_USERNAME: ${{ github.actor }}
         GH_TOKEN: ${{secrets.GH_TOKEN}}


### PR DESCRIPTION
Looks like github actions are again working fine. In the meanwhile, they were moved under the xbmc repository. To make it all work:

1) Merge this PR

2) Delete the previous tag:

```
git tag -d 2.1.0
git push origin :refs/tags/2.1.0
```

3) Tag it again
```
git tag 2.1.0 && git push --tags
```