### PR TITLE
[script.logviewer] 2.1.2

### DIFF
--- a/.github/workflows/addon-submitter.yml
+++ b/.github/workflows/addon-submitter.yml
@@ -14,11 +14,12 @@ jobs:
       uses: actions/checkout@v1
     - name: Generate distribution zip and submit to official kodi repository
       id: kodi-addon-submitter
-      uses: xbmc/action-kodi-addon-submitter@v1.0
+      uses: xbmc/action-kodi-addon-submitter@v1.1
       with: # Replace all the below values
         kodi-repository: repo-scripts
         kodi-version: gotham
         addon-id: script.logviewer
+        kodi-matrix: true
       env: # Make sure you create the below secrets (GH_TOKEN and EMAIL)
         GH_USERNAME: ${{ github.actor }}
         GH_TOKEN: ${{secrets.GH_TOKEN}}

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.1">
+<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.2">
     <requires>
         <import addon="xbmc.python" version="2.14.0"/>
     </requires>
@@ -19,8 +19,7 @@
         <description lang="pt">Ferramenta para verificar e ler facilmente o log do Kodi.</description>
         <platform>all</platform>
         <news>
-- Fix android file handling
-- Add http server (webtail)
+            - Automated submissions to matrix branch
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.2 (8 April 2020):
+- Automated submissions to matrix branch
+
 v2.1.1 (8 December 2019):
 - Fix android file handling
 - Add http server (webtail)


### PR DESCRIPTION
This PR adjusts the CI so that when a new version is tagged the equivalent version is also submitted to matrix (since the addon is already python3 compatible).

The xbmc/kodi-submitter-action automatically will change the dependency of `xbmc.python` to `3.0.0`. At the same time, the addon version will be changed to comply to PEP440: `2.1.2+matrix.1`.

Please tag a release whenever possible so that we can have this addon in matrix too. You just need to do:

```
git pull
git tag 2.1.2 && git push --tags
```