### PR TITLE
v2.1.5: make the matrix version compatible with v20

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.4+matrix.1">
+<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.5+matrix.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -19,7 +19,7 @@
         <description lang="pt_PT">Ferramenta para verificar e ler facilmente o log do Kodi.</description>
         <platform>all</platform>
         <news>
-            - Updated to support Matrix log format
+            - Move xbmc.translatePath to xbmcvfs.translatePath (removed in v20)
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.5 (matrix only)
+- Move xbmc.translatePath to xbmcvfs.translatePath (removed in v20)
+
 v2.1.4 (18 June 2020)
 - Updated to support Matrix log format
 

--- a/resources/lib/logviewer.py
+++ b/resources/lib/logviewer.py
@@ -7,6 +7,7 @@ import time
 
 import xbmc
 import xbmcgui
+import xbmcvfs
 
 from resources.lib.dialog import ACTION_PARENT_DIR, KEY_NAV_BACK, ACTION_PREVIOUS_MENU
 from resources.lib.logreader import LogReader
@@ -38,13 +39,13 @@ def log_location(old=False):
         elif xbmc.getCondVisibility("system.platform.ios"):
             log_path = "/var/mobile/Library/Preferences"
         elif xbmc.getCondVisibility("system.platform.windows"):
-            log_path = xbmc.translatePath("special://home")
+            log_path = xbmcvfs.translatePath("special://home")
         elif xbmc.getCondVisibility("system.platform.linux"):
-            log_path = xbmc.translatePath("special://home/temp")
+            log_path = xbmcvfs.translatePath("special://home/temp")
         else:
-            log_path = xbmc.translatePath("special://logpath")
+            log_path = xbmcvfs.translatePath("special://logpath")
     else:
-        log_path = xbmc.translatePath("special://logpath")
+        log_path = xbmcvfs.translatePath("special://logpath")
 
     try:
         app_name = get_application_name().lower()


### PR DESCRIPTION
xbmc.translatePath was deprecated in Matrix and finally removed in v20