### PR TITLE
Suppress exceptions during exception handling

### DIFF
--- a/resources/lib/httpserver.py
+++ b/resources/lib/httpserver.py
@@ -81,8 +81,11 @@ class ServerHandler(BaseHTTPRequestHandler):
                 self.end_headers()
         except Exception as e:
             logging.error(e)
-            self.send_response(500)
-            self.end_headers()
+            try:
+                self.send_response(500)
+                self.end_headers()
+            except:
+                ...
 
     def send_response_and_end(self, code, message=None):
         self.send_response(code, message=message)


### PR DESCRIPTION
Noticed an issue where interrupted client connections (`wget`) to the httpserver result in a double exception being raised. This change attempts to balance logging the original exception with keeping the log clean but suppressing exceptions that occur during exception handling.

The following log section was observed being repeated once per connection:

```log
2024-08-21 09:04:20.399 T:18036   error <general>: [script.logviewer] [Errno 32] Broken pipe
2024-08-21 09:04:20.400 T:18036   error <general>: ----------------------------------------
2024-08-21 09:04:20.401 T:18036   error <general>: 
                                                   
2024-08-21 09:04:20.401 T:18036   error <general>: Exception occurred during processing of request from
2024-08-21 09:04:20.401 T:18036   error <general>:  
2024-08-21 09:04:20.401 T:18036   error <general>: ('192.168.1.2', 36344)
2024-08-21 09:04:20.401 T:18036   error <general>: 
                                                   
2024-08-21 09:04:20.407 T:18036   error <general>: Traceback (most recent call last):
                                                   
2024-08-21 09:04:20.407 T:18036   error <general>: 
2024-08-21 09:04:20.409 T:18036   error <general>:   File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.logviewer/resources/lib/httpserver.py", line 78, in do_GET
                                                       self.get_routes[self.url.path](self)
                                                   
2024-08-21 09:04:20.409 T:18036   error <general>: 
2024-08-21 09:04:20.410 T:18036   error <general>:   File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.logviewer/resources/lib/httpserver.py", line 51, in tail_handler
                                                       ctx.wfile.write(content)
                                                   
2024-08-21 09:04:20.410 T:18036   error <general>: 
2024-08-21 09:04:20.410 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/socketserver.py", line 834, in write
                                                       self._sock.sendall(b)
                                                   
2024-08-21 09:04:20.410 T:18036   error <general>: 
2024-08-21 09:04:20.410 T:18036   error <general>: BrokenPipeError: [Errno 32] Broken pipe
                                                   
2024-08-21 09:04:20.410 T:18036   error <general>: 
2024-08-21 09:04:20.411 T:18036   error <general>: 
                                                   During handling of the above exception, another exception occurred:
                                                   
                                                   
2024-08-21 09:04:20.411 T:18036   error <general>: 
2024-08-21 09:04:20.411 T:18036   error <general>: Traceback (most recent call last):
                                                   
2024-08-21 09:04:20.411 T:18036   error <general>: 
2024-08-21 09:04:20.415 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/socketserver.py", line 691, in process_request_thread
                                                       self.finish_request(request, client_address)
                                                   
2024-08-21 09:04:20.415 T:18036   error <general>: 
2024-08-21 09:04:20.415 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/socketserver.py", line 361, in finish_request
                                                       self.RequestHandlerClass(request, client_address, self)
                                                   
2024-08-21 09:04:20.415 T:18036   error <general>: 
2024-08-21 09:04:20.416 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/socketserver.py", line 755, in __init__
                                                       self.handle()
                                                   
2024-08-21 09:04:20.416 T:18036   error <general>: 
2024-08-21 09:04:20.416 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/http/server.py", line 436, in handle
                                                       self.handle_one_request()
                                                   
2024-08-21 09:04:20.416 T:18036   error <general>: 
2024-08-21 09:04:20.416 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/http/server.py", line 424, in handle_one_request
                                                       method()
                                                   
2024-08-21 09:04:20.416 T:18036   error <general>: 
2024-08-21 09:04:20.416 T:18036   error <general>:   File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.logviewer/resources/lib/httpserver.py", line 85, in do_GET
                                                       self.end_headers()
                                                   
2024-08-21 09:04:20.417 T:18036   error <general>: 
2024-08-21 09:04:20.417 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/http/server.py", line 538, in end_headers
                                                       self.flush_headers()
                                                   
2024-08-21 09:04:20.417 T:18036   error <general>: 
2024-08-21 09:04:20.417 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/http/server.py", line 542, in flush_headers
                                                       self.wfile.write(b"".join(self._headers_buffer))
                                                   
2024-08-21 09:04:20.417 T:18036   error <general>: 
2024-08-21 09:04:20.417 T:18036   error <general>:   File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.11/lib/python3.11/socketserver.py", line 834, in write
                                                       self._sock.sendall(b)
                                                   
2024-08-21 09:04:20.417 T:18036   error <general>: 
2024-08-21 09:04:20.417 T:18036   error <general>: BrokenPipeError: [Errno 32] Broken pipe
                                                   
2024-08-21 09:04:20.417 T:18036   error <general>: 
2024-08-21 09:04:20.418 T:18036   error <general>: ----------------------------------------
2024-08-21 09:04:20.418 T:18036   error <general>: 
```