### PR TITLE
Fix log line leading space handled differently by Kodi Piers

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.7+matrix.1">
+<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.8+matrix.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.8 (24 Apr 2026)
+- Fix log line leading spaces handled differently by Kodi Piers
+
 v2.1.5 (matrix only)
 - Move xbmc.translatePath to xbmcvfs.translatePath (removed in v20)
 

--- a/resources/lib/logviewer.py
+++ b/resources/lib/logviewer.py
@@ -93,6 +93,16 @@ def set_styles(content):
     return content
 
 
+def preserve_indentation(content):
+    lines = content.splitlines()
+    fixed = []
+    for line in lines:
+        stripped = line.lstrip(' ')
+        n = len(line) - len(stripped)
+        fixed.append('\u00a0' * n + stripped)
+    return '\n'.join(fixed)
+
+
 def parse_errors(content, set_style=False, exceptions_only=False):
     if content == "":
         return ""
@@ -116,6 +126,8 @@ def parse_errors(content, set_style=False, exceptions_only=False):
     if set_style:
         parsed_content = set_styles(parsed_content)
 
+    parsed_content = preserve_indentation(parsed_content)
+
     return parsed_content
 
 
@@ -134,8 +146,9 @@ def get_content(old=False, invert=False, line_number=0, set_style=False):
     if set_style:
         content = set_styles(content)
 
-    return content
+    content = preserve_indentation(content)
 
+    return content
 
 def window(title, content, default=True, timeout=1):
     if default:


### PR DESCRIPTION
**Fix**
Preserve leading whitespace in log output (e.g. stack traces)

**Problem**
Leading spaces at the beginning of log lines (e.g. indented stack traces) are silently stripped when displayed in the Kodi textbox control, breaking the formatting of indented log content.

**Root cause**
The bug was introduced in Kodi 22 Piers (merged via [xbmc/xbmc#27403](https://github.com/xbmc/xbmc/pull/27403)) as an unintended side effect of a `WrapText()` performance optimization in GUITextLayout.cpp.
The new implementation introduced a `skipLeadingSpaces` lambda that is called after every line break during word-wrapping. While intended to avoid leading spaces after automatic line breaks, it inadvertently also strips intentional indentation at the start of lines that follow a wrapped line.

`CGUITextBox` is always initialized with `wrap=true`, so this code path is always active. The bug does not affect Kodi 21 Omega or earlier.

@sundermann fyi